### PR TITLE
Make client keys dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Summary
 This is a command line ruby script that takes an input csv file and an output csv file name as parameters. 
 
-This script will group all vehicles together by person, and label the unique vehicle columns as repeated numbers (i.e `make 1`, `model 1`, `make 2`, `model 2`, etc).
+If the person has more than one vehicle, then this script will group all vehicles together by person, and label the unique vehicle columns as repeated numbers (i.e `make 1`, `model 1`, `make 2`, `model 2`, etc).
 
 ## Usage
 ```ruby
@@ -10,18 +10,7 @@ ruby process.rb -i sample.csv -o output.csv
 ```
 
 ## Assumptions
-- The first column will always be the person identifier 
-- The client columns included in the report will be limited to the following, but not all columns need to be included:  
-  - sfid
-  - first name
-  - last name
-  - address 
-  - city
-  - state
-  - zip code
-  - email
-  - mobile phone
-  - sms permission
+- The first column will always be the person identifier
 - Report will be already sorted by the soonest statute of limitations expiration
 
 ## Concerns


### PR DESCRIPTION
Rather than limiting the column names to a hard coded list, this will allow for more flexibility for whatever data comes in through the input. 

This is to handle if the salesforce data changes the column names, if someone aliases/renames the columns, or if there are additional columns added that were unaccounted for.